### PR TITLE
🦁 [도토리/도토리 가방] 도토리 가방 데이터와 도토리를 한번에 요청받도록 수정

### DIFF
--- a/src/main/java/com/chungkathon/squirrel/controller/DotoriCollectionController.java
+++ b/src/main/java/com/chungkathon/squirrel/controller/DotoriCollectionController.java
@@ -61,6 +61,8 @@ public class DotoriCollectionController {
     public DotoriCollectionCreateDto createDotoriCollection(@PathVariable String urlRnd,
                                                             @RequestParam("requestJson") String requestDtoString,
                                                             @RequestParam("files")List<MultipartFile> files) {
+        int fileCount = files.size();
+
         // 요청 문자열을 JSON으로
         ObjectMapper objectMapper = new ObjectMapper();
         DotoriCollectionCreateRequestDto requestDto;
@@ -76,6 +78,7 @@ public class DotoriCollectionController {
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID에 해당하는 도토리 가방이 존재하지 않습니다."));
         dotoriService.createMultipleDotori(files, dotoriCollection);
 
+        responseDto.setDotoriNum(fileCount);
         return responseDto;
     }
 

--- a/src/main/java/com/chungkathon/squirrel/controller/DotoriCollectionController.java
+++ b/src/main/java/com/chungkathon/squirrel/controller/DotoriCollectionController.java
@@ -9,9 +9,13 @@ import com.chungkathon.squirrel.dto.response.DotoriCollectionResponseDto;
 import com.chungkathon.squirrel.dto.response.QuizResponseDto;
 import com.chungkathon.squirrel.repository.DotoriCollectionJpaRepository;
 import com.chungkathon.squirrel.service.DotoriCollectionService;
+import com.chungkathon.squirrel.service.DotoriService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,10 +28,12 @@ import java.util.stream.Collectors;
 public class DotoriCollectionController {
     private final DotoriCollectionJpaRepository dotoriCollectionJpaRepository;
     private DotoriCollectionService dotoriCollectionService;
+    private DotoriService dotoriService;
 
-    public DotoriCollectionController(DotoriCollectionService dotoriCollectionService, DotoriCollectionJpaRepository dotoriCollectionJpaRepository) {
+    public DotoriCollectionController(DotoriCollectionService dotoriCollectionService, DotoriCollectionJpaRepository dotoriCollectionJpaRepository, DotoriService dotoriService) {
         this.dotoriCollectionService = dotoriCollectionService;
         this.dotoriCollectionJpaRepository = dotoriCollectionJpaRepository;
+        this.dotoriService = dotoriService;
     }
 
     // 사용자별 도토리 주머니 모아보기 (삭제된 도토리 주머니 제외)
@@ -52,8 +58,25 @@ public class DotoriCollectionController {
 
     // 도토리 주머니 생성
     @PostMapping("/{urlRnd}/create")
-    public DotoriCollectionCreateDto createDotoriCollection(@PathVariable String urlRnd, @RequestBody DotoriCollectionCreateRequestDto requestDto) {
-        return dotoriCollectionService.createDotoriCollection(urlRnd, requestDto);
+    public DotoriCollectionCreateDto createDotoriCollection(@PathVariable String urlRnd,
+                                                            @RequestParam("requestJson") String requestDtoString,
+                                                            @RequestParam("files")List<MultipartFile> files) {
+        // 요청 문자열을 JSON으로
+        ObjectMapper objectMapper = new ObjectMapper();
+        DotoriCollectionCreateRequestDto requestDto;
+        try {
+            requestDto = objectMapper.readValue(requestDtoString, DotoriCollectionCreateRequestDto.class);
+            System.out.println(requestDto);
+        } catch (JsonProcessingException e) {
+            throw  new RuntimeException("Invalid JSON String");
+        }
+
+        DotoriCollectionCreateDto responseDto = dotoriCollectionService.createDotoriCollection(urlRnd, requestDto);
+        DotoriCollection dotoriCollection = dotoriCollectionJpaRepository.findById(responseDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID에 해당하는 도토리 가방이 존재하지 않습니다."));
+        dotoriService.createMultipleDotori(files, dotoriCollection);
+
+        return responseDto;
     }
 
     @GetMapping("/{dotori_collection_id}/quiz")

--- a/src/main/java/com/chungkathon/squirrel/dto/request/DotoriCollectionCreateRequestDto.java
+++ b/src/main/java/com/chungkathon/squirrel/dto/request/DotoriCollectionCreateRequestDto.java
@@ -12,7 +12,6 @@ public class DotoriCollectionCreateRequestDto {
     private String sender;
     private String message;
     private boolean lock;
-    private int dotori_num;
     private Quiz quiz;
 
     public String getSender() {

--- a/src/main/java/com/chungkathon/squirrel/service/DotoriCollectionService.java
+++ b/src/main/java/com/chungkathon/squirrel/service/DotoriCollectionService.java
@@ -54,7 +54,7 @@ public class DotoriCollectionService {
                 .message(requestDto.getMessage())
                 .lock(true)
                 .deleted(false)
-                .dotori_num(Math.min(7, Math.max(1, requestDto.getDotori_num())))
+                .dotori_num(0)
                 .quiz(quiz)
                 .build();
 


### PR DESCRIPTION
</br>


## ⏰ PR 생성 날짜
2024/11/17


<br/>

## 📖 카테고리
<!-- 해당하는 카테고리에 v로 표시 -->
<!-- 추가 예정 -->
- [] 회원가입
- [] 퀴즈
- [v] 도토리
- [v] 도토리 가방


<br/>

## 🖼️ 작업 내용
<!-- 카테고리에 해당하는 작업 중 어떤 부분에 대한 작업을 진행했는지 요약 -->
- 도토리 가방과 도토리를 보낼 때 프론트에서 따로 보내야 한다는 문제점이 있었음
- 도토리 가방 JSON을 문자열로 받고, 파일들을 받아 프론트에서 이들을 한 번에 폼데이터로 묶어 보낼 수 있도록 수정
- 프론트에서 도토리 개수 요청 보내지 않고 내부에서 처리

<br/>

## ✅ To-do
<!-- 카테고리에 해당하는 작업 중 앞으로 진행해야 하는 작업 정리 -->
- 프론트와 연결


<br/>

## 📢 Notes
<!-- 전하고 싶은 내용, 논의가 필요한 부분 -->


<br/>
