### PR TITLE
🦁 [퀴즈] 퀴즈 응답 시 사용자 체크

### DIFF
--- a/src/main/java/com/chungkathon/squirrel/config/SecurityConfig.java
+++ b/src/main/java/com/chungkathon/squirrel/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                     auth.requestMatchers("/dotoricollection/{urlRnd:[a-zA-Z0-9\\\\-]+}/create").permitAll();
                     auth.requestMatchers("/dotoricollection/{dotori_collection_id:[a-zA-Z0-9\\\\-]+}/open").permitAll();
                     auth.requestMatchers("/dotoricollection/{dotori_collection_id:[a-zA-Z0-9\\\\-]+}/quiz").permitAll();
-                    auth.requestMatchers("/dotoricollection/{dotori_collection_id:[a-zA-Z0-9\\\\-]+}/reply").permitAll();
+                    auth.requestMatchers("/dotoricollection/{dotori_collection_id:[a-zA-Z0-9\\\\-]+}/reply").authenticated();
                     auth.requestMatchers("/dotori/get/{collectionId:[a-zA-Z0-9\\\\-]+}").permitAll();
                     auth.requestMatchers("/dotori/delete/{dotoriId:[a-zA-Z0-9\\\\-]+}").authenticated();
                     auth.anyRequest().authenticated();

--- a/src/main/java/com/chungkathon/squirrel/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chungkathon/squirrel/jwt/JwtAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String[] EXCLUDED_PATHS = {"/join", "/login", "/api/v1/check", "/join/check", "/h2-console", "/dotori/upload"};
     private static final String[] DYNAMIC_PATH_PATTERN = {"^/dynamic/[a-zA-Z0-9\\-]+$", "^/dotoricollection/[a-zA-Z0-9\\-]+$",
             "^/dotoricollection/[a-zA-Z0-9\\-]+$/create", "^/dotoricollection/[a-zA-Z0-9\\-]+$/quiz",
-            "^/dotoricollection/[a-zA-Z0-9\\-]+$/reply", "/dotoricollection/[a-zA-Z0-9\\-]+$/open",
+            "^/dotoricollection/[a-zA-Z0-9\\-]+$/open",
             "^/dotori/upload/[a-zA-Z0-9\\-]+$", "^/dotori/get/[a-zA-Z0-9\\-]+$"};
 
     @Override

--- a/src/main/java/com/chungkathon/squirrel/service/DotoriCollectionService.java
+++ b/src/main/java/com/chungkathon/squirrel/service/DotoriCollectionService.java
@@ -16,6 +16,8 @@ import com.chungkathon.squirrel.repository.QuizJpaRepository;
 import com.chungkathon.squirrel.repository.QuizReplyJpaRepository;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,29 +87,32 @@ public class DotoriCollectionService {
     }
 
     @Transactional
-    public boolean updateDotoriCollection(Long dotori_collection_id, QuizReplyCreateRequestDto requestDto) {
-        DotoriCollection dotoriCollection = dotoriCollectionJpaRepository.findById(dotori_collection_id)
-                .orElseThrow(() -> new RuntimeException("해당 ID를 가진 도토리 주머니가 없습니다."));
+    public boolean updateDotoriCollection(Boolean isOwner, Long dotori_collection_id, QuizReplyCreateRequestDto requestDto) {
+        if (isOwner) {
+            DotoriCollection dotoriCollection = dotoriCollectionJpaRepository.findById(dotori_collection_id)
+                    .orElseThrow(() -> new RuntimeException("해당 ID를 가진 도토리 주머니가 없습니다."));
 
-        Quiz quiz = dotoriCollection.getQuiz();
-        if (quiz == null) {
-            throw new RuntimeException("도토리 주머니에 연결된 퀴즈가 없습니다.");
-        }
+            Quiz quiz = dotoriCollection.getQuiz();
+            if (quiz == null) {
+                throw new RuntimeException("도토리 주머니에 연결된 퀴즈가 없습니다.");
+            }
 
-        QuizReply quizReply = new QuizReply(quiz, requestDto.getReply());
+            QuizReply quizReply = new QuizReply(quiz, requestDto.getReply());
 //        quizReply.setQuiz(quiz);
 //        quizReply.setReply(requestDto.getReply());
-        quizReplyJpaRepository.save(quizReply);
+            quizReplyJpaRepository.save(quizReply);
 
-        boolean isCorrect = quizService.checkQuizReply(dotoriCollection.getId() , requestDto);
+            boolean isCorrect = quizService.checkQuizReply(dotoriCollection.getId() , requestDto);
 
-        if (isCorrect) { // 퀴즈 정답과 응답이 일치하면
-            dotoriCollection.setLock(false); // 도토리 주머니 잠금 해제
+            if (isCorrect) { // 퀴즈 정답과 응답이 일치하면
+                dotoriCollection.setLock(false); // 도토리 주머니 잠금 해제
+            }
+            else { // 퀴즈 정답과 응답이 불일치하면
+                dotoriCollection.setDeleted(true); // 도토리 주머니 삭제
+            }
+            return isCorrect;
         }
-        else { // 퀴즈 정답과 응답이 불일치하면
-            dotoriCollection.setDeleted(true); // 도토리 주머니 삭제
-        }
-        return isCorrect;
+        return false;
     }
 
     @Transactional
@@ -129,5 +134,27 @@ public class DotoriCollectionService {
     @Transactional
     public List<DotoriCollection> getActiveDotoriCollections(String urlRnd) {
         return dotoriCollectionJpaRepository.findActiveDotoriCollectionsByMember(urlRnd);
+    }
+
+    @Transactional
+    public boolean isDotoriCollectionOwner(Long dotori_collection_id) {
+        // SecurityContext에서 인증 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalArgumentException("로그인된 사용자가 없습니다.");
+        }
+
+        // Principal에서 사용자 이름 가져오기
+        String username = authentication.getName();
+
+        // 사용자 이름으로 Member 엔티티 조회
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. 로그인이 되어 있는지 확인해주세요"));
+
+        DotoriCollection dotoriCollection = dotoriCollectionJpaRepository.findById(dotori_collection_id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 도토리 가방이 존재하지 않습니다."));
+
+        return dotoriCollection.getMember().equals(member);
     }
 }


### PR DESCRIPTION

</br>


## ⏰ PR 생성 날짜
2024/11/17


<br/>

## 📖 카테고리
<!-- 해당하는 카테고리에 v로 표시 -->
<!-- 추가 예정 -->
- [] 회원가입
- [v] 퀴즈
- [] 도토리
- [] 도토리 가방


<br/>

## 🖼️ 작업 내용
<!-- 카테고리에 해당하는 작업 중 어떤 부분에 대한 작업을 진행했는지 요약 -->
- 우선 도토리 가방 서비스에 주어진 도토리 가방이 로그인한 사용자의 것인지 체크하여 boolean을 반환하도록 함
- DotoriCollectionController의 퀴즈 응답에서 isOwner을 통해 인증 후에 작동할 수 있도록 수정
- updateDotoriCollection 서비스에도 isOwner을 사용하여 인증 후에 작동할 수 있도록 수정

<br/>

## ✅ To-do
<!-- 카테고리에 해당하는 작업 중 앞으로 진행해야 하는 작업 정리 -->
- 배포


<br/>

## 📢 Notes
<!-- 전하고 싶은 내용, 논의가 필요한 부분 -->


<br/>
